### PR TITLE
FEAT: add text btn common component

### DIFF
--- a/src/components/common/TextBtn.jsx
+++ b/src/components/common/TextBtn.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import styled from "styled-components";
+
+function TextBtn({ text, size = "small", type }) {
+  return (
+    <Wrapper size={size} type={type}>
+      {text}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.button`
+  margin: 24px 0 12px;
+  width: ${(props) => {
+    switch (props.size) {
+      case "small":
+        return "";
+      case "medium":
+        return "100%";
+      default:
+        return "";
+    }
+  }};
+  padding: ${(props) => {
+    switch (props.size) {
+      case "small":
+        return "7px 17px";
+      case "medium":
+        return "16px";
+      default:
+        return "0.8rem 2rem 0.8rem 2.4rem";
+    }
+  }};
+  background: ${(props) => {
+    switch (props.type) {
+      case "accent":
+        return props.theme.accentColor;
+      case "light":
+        return "white";
+      default:
+        return props.theme.accentColor;
+    }
+  }};
+  color: ${(props) => {
+    switch (props.type) {
+      case "accent":
+        return "white";
+      case "light":
+        return "black";
+      default:
+        return "white";
+    }
+  }};
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: ${(props) => props.theme.bold};
+
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
+export default TextBtn;


### PR DESCRIPTION
# `TextBtn` 공통 컴포넌트 구현 (#16)
## 구현 상세
* `/src/components/common/`
  * `TextBtn.jsx`: `string` type의 `text`, `size`, `type`을 props로 받아 해당 `text`를 표시하는 버튼을 반환하는 컴포넌트 구현

**text**
| 입력값 | 컴포넌트 |
|---------|-----------|
| 버튼에 표시하고자 하는 문구(string) | 문구가 가운데에 표시된 버튼 |

**size**
| 입력값 | 컴포넌트 |
|---------|-----------|
| `"small"` | `padding`이 상하 `7px`, 좌우 `17px` 들어간 버튼 |
| `"medium"` | `padding`이 상하좌우 `16px` 들어가고 `width`가 `100%`인 버튼 |
| 입력값 없음 | `padding`이 상하좌우 `0.8rem 2rem 0.8rem 2.4rem`인 버튼 |

**type**
| 입력값 | 컴포넌트 |
|---------|-----------|
| `"accent"` | 배경 색이 `accentColor(#E50914)`이고 글씨 색이 `white`인 버튼 |
| `"light"` | 배경 색이 `white`이고 글씨 색이 `black`인 버튼 |
| 입력값 없음 | 배경 색이 `accentColor(#E50914)`이고 글씨 색이 `white`인 버튼 |