### PR TITLE
FIX: modify RatingIcon to adjust response data type

### DIFF
--- a/src/components/common/RatingIcon.jsx
+++ b/src/components/common/RatingIcon.jsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 function RatingIcon({ rating }) {
   const setRatingIcon = () => {
     switch (rating) {
-      case 18:
+      case "18":
         return (
           <>
             <path
@@ -17,7 +17,7 @@ function RatingIcon({ rating }) {
             />
           </>
         );
-      case 15:
+      case "15":
         return (
           <>
             <path
@@ -30,7 +30,7 @@ function RatingIcon({ rating }) {
             />
           </>
         );
-      case 12:
+      case "12":
         return (
           <>
             <path
@@ -62,8 +62,8 @@ function RatingIcon({ rating }) {
 }
 
 const SvgIcon = styled.svg`
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 100%;
+  height: 100%;
 `;
 
 export default RatingIcon;


### PR DESCRIPTION
# `RatingIcon` 공통 컴포넌트 수정 (#5)
## 수정 사항
* `src/components/common/`
  * `RatingIcon.jsx`
    * `int` type의 `rating` props를 API response에 맞춰 `string` type으로 수정.
    * 아이콘은 사용하는 곳에 알맞은 사이즈로 수정이 가능하도록 width, height 값을 `100%`로 수정.
