### PR TITLE
Feat/6 common component header

### DIFF
--- a/src/shared/Header.jsx
+++ b/src/shared/Header.jsx
@@ -106,7 +106,7 @@ const Wrapper = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: 3;
   width: 100%;
   background: ${(props) =>
     props.isMenuStyle


### PR DESCRIPTION
# `Header` 컴포넌트의 마우스 오버가 되지 않는 버그 수정
## 변경 전
`Home` 페이지에서 `Header` 컴포넌트에 마우스 오버 시, 사용자 프로필 토글 메뉴가 동작하지 않음.

## 원인
`Home` 페이지의 메인 컨텐츠 이미지 태그 `MainImg` 와 `Header` 컴포넌트가 형제 요소이면서 이미지 태그의 `z-index`를 더 높게 설정해서 Header 컴포넌트가 가려짐.

## 변경 후
`Home` 페이지에서 `Header` 컴포넌트에 마우스 오버 시, 사용자 프로필 토글 메뉴가 동작.
